### PR TITLE
quic: add ver negotiation and retry processing

### DIFF
--- a/README
+++ b/README
@@ -89,6 +89,12 @@ How to Use It
     # sh server_keys.sh
     # sh client_keys.sh
 
+  or for token/retry example test by:
+
+    # cd tools/testing/selftests/net/quic/
+    # sh server_token.sh
+    # sh client_token.sh
+
   and it can also interact with ngtcp2, after building ngtcp2:
 
     # cd ngtcp2/examples/
@@ -109,7 +115,6 @@ TODO
   - Protocol:
     * Add ICMP(v6) TooBig/FragNeeded Prcess and PLPMTUD.
     * Add more socket options and send/recv parameters.
-    * Retry and Version Negotiation.
 
   - Handshake:
     * Adjust code to support more crypto algorithms.

--- a/include/uapi/linux/quic.h
+++ b/include/uapi/linux/quic.h
@@ -43,6 +43,7 @@ enum quic_evt_type {
 	QUIC_EVT_ADDRESS,	/* NEW */
 	QUIC_EVT_TICKET,	/* NEW */
 	QUIC_EVT_KEY,		/* NEW */
+	QUIC_EVT_TOKEN,		/* NEW */
 	QUIC_EVT_MAX,
 };
 
@@ -69,6 +70,10 @@ enum quic_evt_ticket_type {
 
 enum quic_evt_key_type {
 	QUIC_EVT_KEY_NEW,
+};
+
+enum quic_evt_token_type {
+	QUIC_EVT_TOKEN_NEW,
 };
 
 struct quic_evt_msg {
@@ -113,6 +118,10 @@ struct quic_evt_msg {
 /* certificate chain */
 #define QUIC_SOCKOPT_CERT_CHAIN		18
 #define QUIC_SOCKOPT_ROOT_CA		19
+
+/* token */
+#define QUIC_SOCKOPT_NEW_TOKEN		20
+#define QUIC_SOCKOPT_LOAD_TOKEN		21
 
 #define MSG_NOTIFICATION		0x8000
 

--- a/net/quic/msg.c
+++ b/net/quic/msg.c
@@ -25,7 +25,6 @@ static int quic_msg_encrypted_extension_process(struct quic_sock *qs, u8 *p, u32
 static int quic_msg_certificate_process(struct quic_sock *qs, u8 *p, u32 len)
 {
 	struct quic_cert *c, *certs = NULL, *tmp = NULL;
-	struct x509_certificate *x;
 	u8 *cert_p;
 	u32 clen;
 
@@ -42,13 +41,8 @@ static int quic_msg_certificate_process(struct quic_sock *qs, u8 *p, u32 len)
 	while (1) {
 		len = quic_get_fixint_next(&p, 3);
 		pr_debug("cert one len %u\n", len);
-		x = x509_cert_parse(p, len);
-		if (IS_ERR(x))
-			return PTR_ERR(x);
-
-		c = quic_cert_create(x, p, len);
+		c = quic_cert_create(p, len);
 		if (!c) {
-			kfree(x);
 			qs->crypt.certs = certs;
 			return -ENOMEM;
 		}

--- a/net/quic/packet.c
+++ b/net/quic/packet.c
@@ -18,7 +18,7 @@ static struct sk_buff *quic_packet_long_create(struct quic_sock *qs, u8 type)
 	struct quic_vlen *f = qs->packet.f;
 	struct quic_lhdr *hdr;
 	struct sk_buff *skb;
-	__u8 *p;
+	__u8 *p, rv = 0;
 
 	hlen = sizeof(struct udphdr) + qs->af->iphdr_len + MAX_HEADER;
 	len = sizeof(*hdr) + 4 + 2 + qs->cids.dcid.cur->len + qs->cids.scid.cur->len;
@@ -33,20 +33,25 @@ static struct sk_buff *quic_packet_long_create(struct quic_sock *qs, u8 type)
 	} else if (type == QUIC_PKT_0RTT) {
 		qs->packet.pn = qs->packet.ad_tx_pn++;
 		minlen = 0;
+	} else if (type == QUIC_PKT_RETRY || type == QUIC_PKT_VERSION_NEGOTIATION) {
+		rv = 1;
+		dlen = f->len;
 	} else {
 		qs->packet.pn = qs->packet.hs_tx_pn++;
 	}
-	plen = quic_put_pkt_numlen(qs->packet.pn) - 1;
-	qs->packet.pn_len = plen + 1;
-	dlen = qs->packet.pn_len + f->len;
-	if (dlen < minlen) {
-		dlen = minlen;
-		padlen = dlen - (qs->packet.pn_len + f->len);
+	if (!rv) {
+		plen = quic_put_pkt_numlen(qs->packet.pn) - 1;
+		qs->packet.pn_len = plen + 1;
+		dlen = qs->packet.pn_len + f->len;
+		if (dlen < minlen) {
+			dlen = minlen;
+			padlen = dlen - (qs->packet.pn_len + f->len);
+		}
+		rlen = dlen + QUIC_TAGLEN;
+		len += quic_put_varint_len(rlen);
+		qs->packet.pn_off = len;
+		len += dlen;
 	}
-	rlen = dlen + QUIC_TAGLEN;
-	len += quic_put_varint_len(rlen);
-	qs->packet.pn_off = len;
-	len += dlen;
 	pr_debug("remain len: %d, pn_offset: %d, pn_len: %d, len: %d\n",
 		 rlen, qs->packet.pn_off, qs->packet.pn_len, len);
 
@@ -66,7 +71,7 @@ static struct sk_buff *quic_packet_long_create(struct quic_sock *qs, u8 type)
 	p++;
 
 	/* Version */
-	p = quic_put_pkt_num(p, QUIC_VERSION_V1, 4);
+	p = quic_put_pkt_num(p, (type == QUIC_PKT_VERSION_NEGOTIATION ? 0 : QUIC_VERSION_V1), 4);
 
 	/* Various Length Header: dcid and scid */
 	p = quic_put_varint(p, qs->cids.dcid.cur->len);
@@ -77,20 +82,23 @@ static struct sk_buff *quic_packet_long_create(struct quic_sock *qs, u8 type)
 	/* Various Length Header: token */
 	if (type == QUIC_PKT_INITIAL) {
 		p = quic_put_varint(p, qs->token.len);
-		p = quic_put_pkt_data(p, qs->token.v, qs->token.len);
+		p = quic_put_pkt_data(p, qs->token.token, qs->token.len);
 	}
 
 	/* Various Length Header: length */
-	p = quic_put_varint(p, rlen);
-
-	/* Various Length Header: packet number */
-	p = quic_put_pkt_num(p, qs->packet.pn, qs->packet.pn_len);
-	QUIC_SND_CB(skb)->pn = qs->packet.pn;
+	if (!rv) {
+		p = quic_put_varint(p, rlen);
+		/* Various Length Header: packet number */
+		p = quic_put_pkt_num(p, qs->packet.pn, qs->packet.pn_len);
+		QUIC_SND_CB(skb)->pn = qs->packet.pn;
+	}
 	QUIC_SND_CB(skb)->type = type;
 	QUIC_SND_CB(skb)->has_strm = qs->frame.has_strm;
 
 	/* CRYPTO Frame */
 	p = quic_put_pkt_data(p, f->v, f->len);
+	if (type == QUIC_PKT_0RTT) /* keep the early data len for rtx */
+		qs->packet.early_len = f->len;
 	f->len = 0;
 	if (padlen)
 		memset(p, 0, padlen); /* padding frame */
@@ -173,6 +181,12 @@ static int quic_packet_long_process(struct quic_sock *qs, struct sk_buff *skb, u
 	u8 *p = *ptr;
 	int err;
 
+	err = quic_packet_pre_process(qs, skb);
+	if (err) {
+		*ptr = skb->data + skb->len;
+		return 0;
+	}
+
 	p += 1 + 4 + 1 + QUIC_RCV_CB(skb)->scid_len +
 		1 + QUIC_RCV_CB(skb)->dcid_len;
 	if (hdr->type == QUIC_PKT_INITIAL) {
@@ -248,6 +262,190 @@ out:
 	return err;
 }
 
+static int quic_packet_retry_create(struct quic_sock *qs, struct sk_buff *skb)
+{
+	u8 *pseudo, *tag, *p, type = QUIC_PKT_RETRY;
+	struct quic_lhdr *hdr;
+	struct quic_vlen *f;
+	u32 len;
+	int err;
+
+	f = &qs->frame.f[type];
+	f->len = 1 + 8;
+	tag = f->v + f->len;
+	pseudo = tag + 16;
+
+	p = pseudo;
+	p = quic_put_varint(p, qs->cids.scid.cur->len);
+	p = quic_put_pkt_data(p, qs->cids.scid.cur->id, qs->cids.scid.cur->len);
+	*p = 0;
+	hdr = (struct quic_lhdr *)p;
+	hdr->form = 1;
+	hdr->fixed = 1;
+	hdr->type = QUIC_PKT_RETRY;
+	p++;
+	p = quic_put_pkt_num(p, QUIC_VERSION_V1, 4);
+	p = quic_put_varint(p, qs->cids.dcid.cur->len);
+	p = quic_put_pkt_data(p, qs->cids.dcid.cur->id, qs->cids.dcid.cur->len);
+	p = quic_put_varint(p, qs->cids.scid.cur->len);
+	p = quic_put_pkt_data(p, qs->cids.scid.cur->id, qs->cids.scid.cur->len);
+	len = (u32)(p - pseudo);
+	memset(tag, 0, 16);
+	err = quic_crypto_retry_encrypt(qs, pseudo, len, tag);
+	if (err) {
+		pr_warn("retry encrypt err %d\n", err);
+		return err;
+	}
+	pr_debug("retry encrypt tag: %16phN\n", tag);
+
+	p = f->v;
+	p = quic_put_varint(p, 8);
+	p = quic_put_pkt_data(p, qs->lsk->token.token, 8);
+	p = quic_put_pkt_data(p, tag, 16);
+	f->len += 16;
+	qs->packet.f = f;
+	skb = quic_packet_do_create(qs, type);
+	if (skb) {
+		quic_write_queue_enqueue(qs, skb);
+		quic_write_queue_flush(qs);
+	}
+	return 0;
+}
+
+static int quic_packet_retry_process(struct quic_sock *qs, struct sk_buff *skb)
+{
+	struct quic_lhdr *hdr = quic_lhdr(skb);
+	struct quic_sock *lsk = qs->lsk;
+	u8 type = hdr->type, *p;
+	int err, len;
+
+	if (type == QUIC_PKT_INITIAL) {
+		if (!lsk || !lsk->token.token)
+			return 0;
+
+		p = (u8 *)hdr;
+		p += 1 + 4 + 1 + QUIC_RCV_CB(skb)->scid_len +
+			     1 + QUIC_RCV_CB(skb)->dcid_len;
+		len = *p;
+		if (!len) {
+			err = quic_packet_retry_create(qs, skb);
+			if (err)
+				return err;
+			return 1;
+		}
+		p++;
+		if (len == lsk->token.len && !memcmp(lsk->token.token, p, len))
+			return 0;
+		return 1;
+	}
+
+	if (type != QUIC_PKT_RETRY)
+		return 0;
+
+	p = (u8 *)hdr;
+	p += 1 + 4 + 1 + QUIC_RCV_CB(skb)->scid_len +
+		1 + QUIC_RCV_CB(skb)->dcid_len;
+	len = *p;
+	p++;
+
+	kfree(qs->token.token);
+	qs->token.token = quic_mem_dup(p, len);
+	if (!qs->token.token)
+		return -ENOMEM;
+	qs->token.len = len;
+	p += len;
+
+	qs->state = QUIC_CS_CLIENT_INITIAL;
+	skb = quic_packet_create(qs, QUIC_PKT_INITIAL, QUIC_FRAME_CRYPTO);
+	if (!skb)
+		return -ENOMEM;
+	err = quic_crypto_early_keys_install(qs);
+	if (err) {
+		kfree_skb(skb);
+		return err;
+	}
+	quic_write_queue_enqueue(qs, skb);
+
+	if (qs->packet.early_len) {
+		type = QUIC_PKT_0RTT;
+		qs->frame.f[type].len = qs->packet.early_len;
+		qs->packet.type = type;
+		qs->frame.has_strm = 1;
+		qs->packet.f = &qs->frame.f[type];
+		skb = quic_packet_do_create(qs, type);
+		if (!skb)
+			return -ENOMEM;
+		err = quic_crypto_encrypt(qs, skb, type);
+		if (err) {
+			kfree_skb(skb);
+			return -EINVAL;
+		}
+		quic_write_queue_enqueue(qs, skb);
+	}
+
+	err = quic_write_queue_flush(qs);
+	if (err)
+		return err;
+
+	qs->state = QUIC_CS_CLIENT_WAIT_HANDSHAKE;
+	quic_start_hs_timer(qs, 1);
+	return 1;
+}
+
+static int quic_packet_ver_process(struct quic_sock *qs, struct sk_buff *skb)
+{
+	struct quic_rcv_cb *cb = QUIC_RCV_CB(skb);
+	u8 type = QUIC_PKT_VERSION_NEGOTIATION;
+	u8 *p = skb_transport_header(skb);
+	struct quic_vlen *f;
+	u32 ver;
+
+	p++;
+	ver = *((u32 *)p);
+	ver = ntohl(ver);
+	if (!ver) { /* version negotiation packet */
+		qs->inet.sk.sk_err = -EPROTONOSUPPORT;
+		p += 4 + 2 + cb->dcid_len + cb->scid_len;
+		ver = ntohl(*((u32 *)p));
+		pr_warn("peer supported version is %x\n", ver);
+
+		return -EPROTONOSUPPORT;
+	}
+
+	if (ver == QUIC_VERSION_V1)
+		return 0;
+
+	/* unsupported version */
+	pr_warn("unsupported version %x\n", ver);
+	f = &qs->frame.f[type];
+	f->len = 4;
+	quic_put_pkt_num(f->v, QUIC_VERSION_V1, 4);
+	qs->packet.f = f;
+	skb = quic_packet_do_create(qs, type);
+	if (skb) {
+		quic_write_queue_enqueue(qs, skb);
+		quic_write_queue_flush(qs);
+	}
+
+	return -EPROTONOSUPPORT;
+}
+
+/* exported */
+int quic_packet_pre_process(struct quic_sock *qs, struct sk_buff *skb)
+{
+	int err;
+
+	err = quic_packet_ver_process(qs, skb);
+	if (err)
+		return err;
+
+	err = quic_packet_retry_process(qs, skb);
+	if (err < 0)
+		pr_warn("pkt retry process err %d\n", err);
+
+	return err;
+}
+
 /* exported */
 int quic_packet_process(struct quic_sock *qs, struct sk_buff *skb)
 {
@@ -284,7 +482,7 @@ int quic_packet_process(struct quic_sock *qs, struct sk_buff *skb)
 		f = &qs->frame.f[i];
 		if (!f->len)
 			continue;
-		type = (i >= QUIC_PKT_SHORT + 1) ? QUIC_PKT_HANDSHAKE : i;
+		type = (i > QUIC_PKT_VERSION_NEGOTIATION) ? QUIC_PKT_HANDSHAKE : i;
 		qs->packet.f = f;
 		skb = quic_packet_do_create(qs, type);
 		if (!skb)

--- a/tools/testing/selftests/net/quic/client_token.sh
+++ b/tools/testing/selftests/net/quic/client_token.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+
+gcc quic_client_token.c -o quic_client_token
+./quic_client_token

--- a/tools/testing/selftests/net/quic/quic_client_token.c
+++ b/tools/testing/selftests/net/quic/quic_client_token.c
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* QUIC kernel implementation
+ * (C) Copyright Red Hat Corp. 2021
+ *
+ * This file is part of the QUIC kernel implementation
+ *
+ * Initialization/cleanup for QUIC protocol support.
+ *
+ * Written or modified by:
+ *    Xin Long <lucien.xin@gmail.com>
+ */
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+
+struct quic_sndinfo {
+	uint32_t stream_id;
+};
+
+struct quic_rcvinfo {
+	uint32_t stream_id;
+};
+
+enum quic_cmsg_type {
+	QUIC_SNDINFO,
+	QUIC_RCVINFO,
+};
+
+enum quic_evt_type {
+	QUIC_EVT_CIDS,          /* NEW, DEL, CUR */
+	QUIC_EVT_STREAMS,       /* RESET, STOP, MAX, BLOCKED */
+	QUIC_EVT_ADDRESS,       /* NEW */
+	QUIC_EVT_TICKET,        /* NEW */
+	QUIC_EVT_KEY,           /* NEW */
+	QUIC_EVT_TOKEN,         /* NEW */
+	QUIC_EVT_MAX,
+};
+
+struct quic_evt_msg {
+	uint8_t evt_type;
+	uint8_t sub_type;
+	uint32_t value[3];
+	uint8_t data[];
+};
+
+#define IPPROTO_QUIC	144
+#define SOL_QUIC	144
+
+#define QUIC_SOCKOPT_EVENT		13
+#define QUIC_SOCKOPT_EVENTS		14
+
+#define QUIC_SOCKOPT_NEW_TOKEN          20
+#define QUIC_SOCKOPT_LOAD_TOKEN         21
+
+#define MSG_NOTIFICATION                0x8000
+
+int quic_recvmsg(int s, void *msg, size_t len, struct quic_rcvinfo *rinfo, int *msg_flags)
+{
+	char incmsg[CMSG_SPACE(sizeof(struct quic_rcvinfo))];
+	struct cmsghdr *cmsg = NULL;
+	struct msghdr inmsg;
+	struct iovec iov;
+	int error;
+
+	memset(&inmsg, 0, sizeof(inmsg));
+
+	iov.iov_base = msg;
+	iov.iov_len = len;
+
+	inmsg.msg_name = NULL;
+	inmsg.msg_namelen = 0;
+	inmsg.msg_iov = &iov;
+	inmsg.msg_iovlen = 1;
+	inmsg.msg_control = incmsg;
+	inmsg.msg_controllen = sizeof(incmsg);
+
+	error = recvmsg(s, &inmsg, msg_flags ? *msg_flags : 0);
+	if (error < 0)
+		return error;
+
+	if (msg_flags)
+		*msg_flags = inmsg.msg_flags;
+
+	if (!rinfo)
+		return error;
+
+	for (cmsg = CMSG_FIRSTHDR(&inmsg); cmsg != NULL; cmsg = CMSG_NXTHDR(&inmsg, cmsg))
+		if (SOL_QUIC == cmsg->cmsg_level && QUIC_RCVINFO == cmsg->cmsg_type)
+			break;
+	if (cmsg)
+		memcpy(rinfo, CMSG_DATA(cmsg), sizeof(struct quic_rcvinfo));
+
+	return error;
+}
+
+int quic_sendmsg(int s, const void *msg, size_t len, uint32_t flags, uint32_t stream_id)
+{
+	struct quic_sndinfo *sinfo;
+	struct msghdr outmsg;
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+	char outcmsg[CMSG_SPACE(sizeof(*sinfo))];
+
+	outmsg.msg_name = NULL;
+	outmsg.msg_namelen = 0;
+	outmsg.msg_iov = &iov;
+	iov.iov_base = (void *)msg;
+	iov.iov_len = len;
+	outmsg.msg_iovlen = 1;
+
+	outmsg.msg_control = outcmsg;
+	outmsg.msg_controllen = sizeof(outcmsg);
+	outmsg.msg_flags = 0;
+
+	cmsg = CMSG_FIRSTHDR(&outmsg);
+	cmsg->cmsg_level = SOL_QUIC;
+	cmsg->cmsg_type = 0;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(struct quic_sndinfo));
+
+	outmsg.msg_controllen = cmsg->cmsg_len;
+	sinfo = (struct quic_sndinfo *)CMSG_DATA(cmsg);
+	memset(sinfo, 0, sizeof(struct quic_sndinfo));
+	sinfo->stream_id = stream_id;
+
+	return sendmsg(s, &outmsg, flags);
+}
+
+int get_token(char **buf)
+{
+	*buf = malloc(8);
+	if (!(*buf))
+		return -ENOMEM;
+	memset(*buf, 0x1, 8);
+
+	return 8;
+}
+
+int main(void)
+{
+	int sd, ret, buf_len, events, len, msg_flags;
+	struct sockaddr_in s_addr, c_addr;
+	char s_msg[2000], c_msg[2000];
+	struct quic_rcvinfo r;
+	char *buf, type;
+
+	sd = socket(AF_INET, SOCK_STREAM, IPPROTO_QUIC);
+
+	c_addr.sin_family = AF_INET;
+	c_addr.sin_port = htons(4321);
+	c_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (bind(sd, (struct sockaddr *)&c_addr, sizeof(c_addr)) < 0) {
+		printf("Unable to bind\n");
+		return -1;
+	}
+
+	s_addr.sin_family = AF_INET;
+	s_addr.sin_port = htons(1234);
+	s_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (connect(sd, (struct sockaddr *)&s_addr, sizeof(s_addr)) < 0) {
+		printf("Unable to connect %d\n", errno);
+		return -1;
+	}
+
+	sleep(1);
+	events = (1 << QUIC_EVT_TOKEN);
+	len = sizeof(events);
+	ret = setsockopt(sd, SOL_QUIC, QUIC_SOCKOPT_EVENTS, &events, len);
+	if (ret < 0) {
+		printf("setsockopt %u %u\n", ret, errno);
+		return 1;
+	}
+
+	sleep(1);
+	len = sizeof(events);
+	ret = getsockopt(sd, SOL_QUIC, QUIC_SOCKOPT_EVENTS, &events, &len);
+	if (ret < 0) {
+		printf("getsockopt %u %u\n", ret, errno);
+		return 1;
+	}
+	printf("events %u\n", events);
+
+	memset(s_msg, 0, sizeof(s_msg));
+	ret = quic_recvmsg(sd, s_msg, sizeof(s_msg), &r, &msg_flags);
+	if (ret == -1) {
+		printf("recv %d %d\n", ret, errno);
+		return 1;
+	}
+	printf("recv %d\n", ret);
+	if (msg_flags & MSG_NOTIFICATION) {
+		type = s_msg[0];
+		if (type == QUIC_EVT_TOKEN)  {
+			struct quic_evt_msg *es = (struct quic_evt_msg *)s_msg;
+
+			printf("notification type %u, %u: %u, %u, %u\n",
+				es->evt_type, es->sub_type,
+				es->value[0], es->value[1], es->value[2]);
+			buf = es->data;
+			buf_len = es->value[0];
+			sleep(3);
+			close(sd);
+		}
+	}
+
+	sd = socket(AF_INET, SOCK_STREAM, IPPROTO_QUIC);
+
+	c_addr.sin_family = AF_INET;
+	c_addr.sin_port = htons(4321);
+	c_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (bind(sd, (struct sockaddr *)&c_addr, sizeof(c_addr)) < 0) {
+		printf("Unable to bind\n");
+		return -1;
+	}
+
+	if (setsockopt(sd, SOL_QUIC, QUIC_SOCKOPT_LOAD_TOKEN, buf, buf_len) < 0) {
+		printf("Unable to setsockopt token %d\n", errno);
+		return -1;
+	}
+
+	s_addr.sin_family = AF_INET;
+	s_addr.sin_port = htons(1234);
+	s_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (connect(sd, (struct sockaddr *)&s_addr, sizeof(s_addr)) < 0) {
+		printf("Unable to connect %d\n", errno);
+		return -1;
+	}
+
+	sleep(1);
+	memset(c_msg, 'c', sizeof(c_msg) - 1);
+	ret = quic_sendmsg(sd, c_msg, strlen(c_msg), 0, 0);
+	if (ret == -1) {
+		printf("send %d %d\n", ret, errno);
+		sleep(100);
+		return 1;
+	}
+	printf("send %d\n", ret);
+
+	sleep(1);
+	memset(s_msg, 0, sizeof(s_msg));
+	ret = quic_recvmsg(sd, s_msg, sizeof(s_msg), &r, 0);
+	if (ret == -1) {
+		printf("recv %d %d\n", ret, errno);
+		return 1;
+	}
+	printf("recv %d %d %s\n", ret, r.stream_id, s_msg);
+
+	memset(s_msg, 0, sizeof(s_msg));
+	ret = quic_recvmsg(sd, s_msg, sizeof(s_msg), &r, 0);
+	if (ret == -1) {
+		printf("recv %d %d\n", ret, errno);
+		return 1;
+	}
+	printf("recv %d %d %s\n", ret, r.stream_id, s_msg);
+
+	sleep(2);
+	close(sd);
+	return 0;
+}

--- a/tools/testing/selftests/net/quic/quic_server_token.c
+++ b/tools/testing/selftests/net/quic/quic_server_token.c
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* QUIC kernel implementation
+ * (C) Copyright Red Hat Corp. 2021
+ *
+ * This file is part of the QUIC kernel implementation
+ *
+ * Initialization/cleanup for QUIC protocol support.
+ *
+ * Written or modified by:
+ *    Xin Long <lucien.xin@gmail.com>
+ */
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+
+struct quic_sndinfo {
+	uint32_t stream_id;
+};
+
+struct quic_rcvinfo {
+	uint32_t stream_id;
+};
+
+enum quic_cmsg_type {
+	QUIC_SNDINFO,
+	QUIC_RCVINFO,
+};
+
+enum quic_evt_type {
+	QUIC_EVT_CIDS,          /* NEW, DEL, CUR */
+	QUIC_EVT_STREAMS,       /* RESET, STOP, MAX, BLOCKED */
+	QUIC_EVT_ADDRESS,       /* NEW */
+	QUIC_EVT_TICKET,        /* NEW */
+	QUIC_EVT_KEY,           /* NEW */
+	QUIC_EVT_TOKEN,         /* NEW */
+	QUIC_EVT_MAX,
+};
+
+struct quic_evt_msg {
+	uint8_t evt_type;
+	uint8_t sub_type;
+	uint32_t value[3];
+};
+
+#define IPPROTO_QUIC	144
+#define SOL_QUIC	144
+
+#define QUIC_SOCKOPT_EVENT		13
+#define QUIC_SOCKOPT_EVENTS		14
+
+#define QUIC_SOCKOPT_NEW_TOKEN          20
+#define QUIC_SOCKOPT_LOAD_TOKEN         21
+
+#define MSG_NOTIFICATION		0x8000
+
+int quic_recvmsg(int s, void *msg, size_t len, struct quic_rcvinfo *rinfo, int *msg_flags)
+{
+	char incmsg[CMSG_SPACE(sizeof(struct quic_rcvinfo))];
+	struct cmsghdr *cmsg = NULL;
+	struct msghdr inmsg;
+	struct iovec iov;
+	int error;
+
+	memset(&inmsg, 0, sizeof(inmsg));
+
+	iov.iov_base = msg;
+	iov.iov_len = len;
+
+	inmsg.msg_name = NULL;
+	inmsg.msg_namelen = 0;
+	inmsg.msg_iov = &iov;
+	inmsg.msg_iovlen = 1;
+	inmsg.msg_control = incmsg;
+	inmsg.msg_controllen = sizeof(incmsg);
+
+	error = recvmsg(s, &inmsg, msg_flags ? *msg_flags : 0);
+	if (error < 0)
+		return error;
+
+	if (msg_flags)
+		*msg_flags = inmsg.msg_flags;
+
+	if (!rinfo)
+		return error;
+
+	for (cmsg = CMSG_FIRSTHDR(&inmsg); cmsg != NULL; cmsg = CMSG_NXTHDR(&inmsg, cmsg))
+		if (SOL_QUIC == cmsg->cmsg_level && QUIC_RCVINFO == cmsg->cmsg_type)
+			break;
+	if (cmsg)
+		memcpy(rinfo, CMSG_DATA(cmsg), sizeof(struct quic_rcvinfo));
+
+	return error;
+}
+
+int quic_sendmsg(int s, const void *msg, size_t len, uint32_t flags, uint32_t stream_id)
+{
+	struct quic_sndinfo *sinfo;
+	struct msghdr outmsg;
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+	char outcmsg[CMSG_SPACE(sizeof(*sinfo))];
+
+	outmsg.msg_name = NULL;
+	outmsg.msg_namelen = 0;
+	outmsg.msg_iov = &iov;
+	iov.iov_base = (void *)msg;
+	iov.iov_len = len;
+	outmsg.msg_iovlen = 1;
+
+	outmsg.msg_control = outcmsg;
+	outmsg.msg_controllen = sizeof(outcmsg);
+	outmsg.msg_flags = 0;
+
+	cmsg = CMSG_FIRSTHDR(&outmsg);
+	cmsg->cmsg_level = SOL_QUIC;
+	cmsg->cmsg_type = 0;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(struct quic_sndinfo));
+
+	outmsg.msg_controllen = cmsg->cmsg_len;
+	sinfo = (struct quic_sndinfo *)CMSG_DATA(cmsg);
+	memset(sinfo, 0, sizeof(struct quic_sndinfo));
+	sinfo->stream_id = stream_id;
+
+	return sendmsg(s, &outmsg, flags);
+}
+
+int get_cert(char **buf)
+{
+	int fd = open("./ss_cert/cert.der", O_RDONLY);
+	struct stat sb;
+
+	if (fd == -1)
+		return -1;
+	if (stat("./ss_cert/cert.der", &sb) == -1)
+		return -1;
+
+	*buf = malloc(sb.st_size);
+	if (!(*buf))
+		return -ENOMEM;
+	read(fd, *buf, sb.st_size);
+
+	close(fd);
+	return sb.st_size;
+}
+
+int get_token(char **buf)
+{
+	*buf = malloc(8);
+	if (!(*buf))
+		return -ENOMEM;
+	memset(*buf, 0x1, 8);
+
+	return 8;
+}
+
+int get_pkey(char **buf)
+{
+	int fd = open("./ss_cert/pkey.der", O_RDONLY);
+	struct stat sb;
+
+	if (fd == -1)
+		return -1;
+	if (stat("./ss_cert/pkey.der", &sb) == -1)
+		return -1;
+
+	*buf = malloc(sb.st_size);
+	if (!(*buf))
+		return -ENOMEM;
+	read(fd, *buf, sb.st_size);
+
+	close(fd);
+	return sb.st_size;
+}
+
+#define MSG_LEN	1999
+int main(void)
+{
+	int sd, ret, buf_len, ad, addr_len, events, len, msg_flags;
+	char s_msg[MSG_LEN + 1], c_msg[MSG_LEN + 1];
+	struct sockaddr_in s_addr, c_addr;
+	struct quic_rcvinfo r;
+	char *buf, type;
+
+	sd = socket(AF_INET, SOCK_STREAM, IPPROTO_QUIC);
+
+	memset(&s_addr, 0x00, sizeof(s_addr));
+	s_addr.sin_family = AF_INET;
+	s_addr.sin_port = htons(1234);
+	s_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (bind(sd, (struct sockaddr *)&s_addr, sizeof(s_addr)) < 0) {
+		printf("Unable to bind\n");
+		return -1;
+	}
+
+	buf_len = get_token(&buf);
+	if (setsockopt(sd, SOL_QUIC, QUIC_SOCKOPT_LOAD_TOKEN, buf, buf_len) < 0) {
+		printf("Unable to setsockopt token %d\n", errno);
+		return -1;
+	}
+
+	if (listen(sd, 3)) {
+		printf("Unable to listen\n");
+		return -1;
+	}
+
+	buf_len = get_cert(&buf);
+	printf("Cert File %d\n", buf_len);
+	if (setsockopt(sd, SOL_QUIC, 0, buf, buf_len) < 0) {
+		printf("Unable to setsockopt cert %d\n", errno);
+		return -1;
+	}
+
+	buf_len = get_pkey(&buf);
+	printf("Priv_key File %d\n", buf_len);
+	if (setsockopt(sd, SOL_QUIC, 1, buf, buf_len) < 0) {
+		printf("Unable to setsockopt pkey %d\n", errno);
+		return -1;
+	}
+
+	ad = accept(sd, (struct sockaddr *)&c_addr, &addr_len);
+	if (ad == -1) {
+		printf("Unable to accept %d\n", errno);
+		return -1;
+	}
+
+	sleep(1);
+	events = (1 << QUIC_EVT_TOKEN);
+	len = sizeof(events);
+	ret = setsockopt(ad, SOL_QUIC, QUIC_SOCKOPT_EVENTS, &events, len);
+	if (ret < 0) {
+		printf("setsockopt %u %u\n", ret, errno);
+		return 1;
+	}
+
+	sleep(1);
+	len = sizeof(events);
+	ret = getsockopt(ad, SOL_QUIC, QUIC_SOCKOPT_EVENTS, &events, &len);
+	if (ret < 0) {
+		printf("getsockopt %u %u\n", ret, errno);
+		return 1;
+	}
+	printf("events %u\n", events);
+
+	if (setsockopt(ad, SOL_QUIC, QUIC_SOCKOPT_NEW_TOKEN, NULL, 0) < 0) {
+		printf("Unable to setsockopt token %d\n", errno);
+		return -1;
+	}
+
+	memset(s_msg, 0, sizeof(s_msg));
+	msg_flags = MSG_MORE;
+	ret = quic_recvmsg(ad, s_msg, sizeof(s_msg), &r, &msg_flags);
+	if (ret == -1) {
+		printf("recv %d %d\n", ret, errno);
+		return 1;
+	}
+	printf("recv %d\n", ret);
+	if (msg_flags & MSG_NOTIFICATION) {
+		type = s_msg[0];
+		if (type == QUIC_EVT_TOKEN)  {
+			struct quic_evt_msg *es = (struct quic_evt_msg *)s_msg;
+
+			printf("notification type %u, %u: %u, %u, %u\n",
+					es->evt_type, es->sub_type,
+					es->value[0], es->value[1], es->value[2]);
+			sleep(3);
+			close(ad);
+		}
+	}
+
+	ad = accept(sd, (struct sockaddr *)&c_addr, &addr_len);
+	if (ad == -1) {
+		printf("Unable to accept %d\n", errno);
+		return -1;
+	}
+
+	sleep(1);
+	memset(s_msg, 's', sizeof(s_msg) - 1);
+	ret = quic_sendmsg(ad, s_msg, strlen(s_msg), 0, 3);
+	if (ret == -1) {
+		printf("send %d %d\n", ret, errno);
+		return 1;
+	}
+
+	sleep(1);
+	memset(c_msg, 0, sizeof(c_msg));
+	ret = quic_recvmsg(ad, c_msg, sizeof(c_msg), &r, 0);
+	if (ret == -1) {
+		printf("recv %d %d\n", ret, errno);
+		return 1;
+	}
+	printf("recv %d %d %s\n", ret, r.stream_id, c_msg);
+
+	memset(c_msg, 0, sizeof(c_msg));
+	ret = quic_recvmsg(ad, c_msg, sizeof(c_msg), &r, 0);
+	if (ret == -1) {
+		printf("recv %d %d\n", ret, errno);
+		return 1;
+	}
+	printf("recv %d %d %s\n", ret, r.stream_id, c_msg);
+
+	sleep(2);
+	close(ad);
+	close(sd);
+	return 0;
+}

--- a/tools/testing/selftests/net/quic/server_token.sh
+++ b/tools/testing/selftests/net/quic/server_token.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+
+modprobe quic
+echo "file net/quic/* +p" > /sys/kernel/debug/dynamic_debug/control
+gcc quic_server_token.c -o quic_server_token
+ip link set lo mtu 1500
+./quic_server_token


### PR DESCRIPTION
Other than ver negotiation and retry processing, this patch
also adds token related processing.

Signed-off-by: Xin Long <lucien.xin@gmail.com>