### PR TITLE
tls_hs: add suppport for general tcp tls hs apis

### DIFF
--- a/include/crypto/tls_hs.h
+++ b/include/crypto/tls_hs.h
@@ -22,13 +22,42 @@ enum {
 	TLS_T_CRT,
 	TLS_T_MSG,
 	TLS_T_EXT,
-	TLS_T_TEA,
-	TLS_T_REA,
-	TLS_T_THS,
-	TLS_T_RHS,
-	TLS_T_TAP,
-	TLS_T_RAP,
+	TLS_T_CMSG,
+	TLS_T_EARLY,
 }; /* hs opt type */
+
+enum {
+	TLS_SE_DHE,
+	TLS_SE_RMS,
+
+	/* early data keys */
+	TLS_SE_EA,
+	TLS_SE_TEA,
+	TLS_SE_TEA_KEY,
+	TLS_SE_TEA_IV,
+	TLS_SE_REA,
+	TLS_SE_REA_KEY,
+	TLS_SE_REA_IV,
+
+	/* handshake keys */
+	TLS_SE_HS,
+	TLS_SE_THS,
+	TLS_SE_THS_KEY,
+	TLS_SE_THS_IV,
+	TLS_SE_RHS,
+	TLS_SE_RHS_KEY,
+	TLS_SE_RHS_IV,
+
+	/* application keys */
+	TLS_SE_MS,
+	TLS_SE_TAP,
+	TLS_SE_TAP_KEY,
+	TLS_SE_TAP_IV,
+	TLS_SE_RAP,
+	TLS_SE_RAP_KEY,
+	TLS_SE_RAP_IV,
+	TLS_SE_MAX,
+}; /* hs key type */
 
 enum {
 	TLS_P_NONE,
@@ -56,16 +85,32 @@ static inline struct tls_vec *tls_vec(struct tls_vec *vec, u8 *data, u32 len)
 }
 
 struct tls_hs;
+struct socket;
 
+/* Low Level TLS 1.3 Handshake APIs */
 int tls_handshake_create(struct tls_hs **tlsp, bool is_serv, gfp_t gfp);
 void tls_handshake_destroy(struct tls_hs *tls);
 
-int tls_handshake(struct tls_hs *tls, struct tls_vec *imsg, struct tls_vec *omsg);
+int tls_handshake(struct tls_hs *tls, struct tls_vec *msg);
 int tls_handshake_set(struct tls_hs *tls, u8 type, struct tls_vec *vec);
 int tls_handshake_get(struct tls_hs *tls, u8 type, struct tls_vec *vec);
-int tls_handshake_post(struct tls_hs *tls, u8 type, struct tls_vec *imsg, struct tls_vec *omsg);
+int tls_handshake_post(struct tls_hs *tls, u8 type, struct tls_vec *msg);
 
 int tls_hkdf_expand(struct tls_hs *tls, struct tls_vec *s, struct tls_vec *l, struct tls_vec *k);
 int tls_hkdf_extract(struct tls_hs *tls, struct tls_vec *s, struct tls_vec *l, struct tls_vec *k);
+int tls_secret_get(struct tls_hs *tls, u8 type, struct tls_vec *vec);
 
+#define TLS_F_SERV		0x1
+#define TLS_F_PSK		0x2
+#define TLS_F_CRT		0x4
+#define TLS_F_CRT_REQ		0x8
+#define TLS_F_NO_KTLS		0x10
+
+/* General TCP TLS 1.3 Handshake APIs */
+struct tls_hs *tls_gen_handshake(struct socket *sock, struct tls_vec *msg, char *subsys, u8 flag);
+int tls_gen_handshake_post(struct socket *sock, struct tls_hs *tls, u8 type, struct tls_vec *msg);
+
+/* En/Decrypt msg when tls_gen is used without KTLS. */
+int tls_gen_encrypt(struct tls_hs *tls, struct tls_vec *msg, u32 seq);
+int tls_gen_decrypt(struct tls_hs *tls, struct tls_vec *msg, u32 seq);
 #endif /* __net_tls_hs_h__ */

--- a/include/uapi/linux/tcp.h
+++ b/include/uapi/linux/tcp.h
@@ -128,6 +128,7 @@ enum {
 #define TCP_CM_INQ		TCP_INQ
 
 #define TCP_TX_DELAY		37	/* delay outgoing packets by XX usec */
+#define TCP_TLS_HS		38	/* do tls 1.3 handshake in kernel */
 
 
 #define TCP_REPAIR_ON		1

--- a/net/ipv4/tcp.c
+++ b/net/ipv4/tcp.c
@@ -279,6 +279,7 @@
 #include <linux/uaccess.h>
 #include <asm/ioctls.h>
 #include <net/busy_poll.h>
+#include <crypto/tls_hs.h>
 
 /* Track pending CMSGs. */
 enum {
@@ -4260,6 +4261,44 @@ zerocopy_rcv_inq:
 zerocopy_rcv_out:
 		if (!err && copy_to_user(optval, &zc, len))
 			err = -EFAULT;
+		return err;
+	}
+#endif
+#if IS_BUILTIN(CONFIG_CRYPTO_TLS_HS)
+	case TCP_TLS_HS: {
+		struct tls_vec vec = {NULL, 0};
+		struct tls_hs *tls;
+		u8 *p, flag;
+		int err = 0;
+
+		if (get_user(len, optlen) || len < 1)
+			return -EFAULT;
+		p = memdup_user(optval, len);
+		if (IS_ERR(p))
+			return PTR_ERR(p);
+
+		flag = *p; /* get flag for tls setup */
+		if (len >= 5) { /* get early data to send */
+			tls_vec(&vec, p + 5, *((u32 *)(p + 1)));
+			if (len - 5 < vec.len) {
+				err = -EINVAL;
+				goto tls_err;
+			}
+		}
+
+		tls = tls_gen_handshake(sk->sk_socket, &vec, "tcp", flag);
+		if (IS_ERR(tls)) {
+			err = PTR_ERR(tls);
+			goto tls_err;
+		}
+
+		/* copy it back if there is early data received */
+		if (len < vec.len || put_user(vec.len, optlen) ||
+		    (vec.len && copy_to_user(optval, vec.data, vec.len)))
+			err = -EFAULT;
+		tls_handshake_destroy(tls);
+tls_err:
+		kfree(p);
 		return err;
 	}
 #endif

--- a/net/quic/crypto.c
+++ b/net/quic/crypto.c
@@ -419,7 +419,7 @@ int quic_crypto_early_keys_install(struct quic_sock *qs)
 	struct tls_vec srt = {NULL, 0}, k, iv, hp_k;
 	int err;
 
-	err = tls_handshake_get(qs->tls, TLS_T_TEA, &srt);
+	err = tls_secret_get(qs->tls, TLS_SE_TEA, &srt);
 	if (err)
 		return err;
 
@@ -431,7 +431,7 @@ int quic_crypto_early_keys_install(struct quic_sock *qs)
 		return err;
 	pr_debug("[QUIC] ea tx keys: %16phN, %12phN, %16phN\n", k.data, iv.data, hp_k.data);
 
-	err = tls_handshake_get(qs->tls, TLS_T_REA, &srt);
+	err = tls_secret_get(qs->tls, TLS_SE_REA, &srt);
 	if (err)
 		return err;
 
@@ -450,7 +450,7 @@ int quic_crypto_handshake_keys_install(struct quic_sock *qs)
 	struct tls_vec srt = {NULL, 0}, k, iv, hp_k;
 	int err;
 
-	err = tls_handshake_get(qs->tls, TLS_T_THS, &srt);
+	err = tls_secret_get(qs->tls, TLS_SE_THS, &srt);
 	if (err)
 		return err;
 
@@ -462,7 +462,7 @@ int quic_crypto_handshake_keys_install(struct quic_sock *qs)
 		return err;
 	pr_debug("[QUIC] hs tx keys: %16phN, %12phN, %16phN\n", k.data, iv.data, hp_k.data);
 
-	err = tls_handshake_get(qs->tls, TLS_T_RHS, &srt);
+	err = tls_secret_get(qs->tls, TLS_SE_RHS, &srt);
 	if (err)
 		return err;
 
@@ -482,7 +482,7 @@ int quic_crypto_application_keys_install(struct quic_sock *qs)
 	u8 p = qs->crypt.key_phase;
 	int err;
 
-	err = tls_handshake_get(qs->tls, TLS_T_TAP, &srt);
+	err = tls_secret_get(qs->tls, TLS_SE_TAP, &srt);
 	if (err)
 		return err;
 
@@ -494,7 +494,7 @@ int quic_crypto_application_keys_install(struct quic_sock *qs)
 		return err;
 	pr_debug("[QUIC] ap tx keys: %16phN, %12phN, %16phN\n", k.data, iv.data, hp_k.data);
 
-	err = tls_handshake_get(qs->tls, TLS_T_RAP, &srt);
+	err = tls_secret_get(qs->tls, TLS_SE_RAP, &srt);
 	if (err)
 		return err;
 
@@ -510,10 +510,10 @@ int quic_crypto_application_keys_install(struct quic_sock *qs)
 
 int quic_crypto_key_update(struct quic_sock *qs)
 {
-	struct tls_vec l = {"quic ku", 7}, vec;
+	struct tls_vec vec = {"quic ku", 7};
 	int err;
 
-	err = tls_handshake_post(qs->tls, TLS_P_KEY_UPDATE, &l, &vec);
+	err = tls_handshake_post(qs->tls, TLS_P_KEY_UPDATE, &vec);
 	if (err)
 		return err;
 	qs->crypt.key_phase = !!qs->crypt.key_phase;

--- a/net/quic/frame.c
+++ b/net/quic/frame.c
@@ -90,7 +90,7 @@ static int quic_frame_ch_crypto_create(struct quic_sock *qs)
                 return err;
 	f->len = 0;
 
-        err = tls_handshake(qs->tls, NULL, &vec);
+        err = tls_handshake(qs->tls, tls_vec(&vec, NULL, 0));
         if (err < 0)
                 return err;
 
@@ -667,7 +667,7 @@ static int quic_frame_crypto_process(struct quic_sock *qs, u8 **ptr, u8 type, u3
 
 	if (qs->state == QUIC_CS_CLIENT_POST_HANDSHAKE ||
 	    qs->state == QUIC_CS_SERVER_POST_HANDSHAKE) {
-		ret = tls_handshake_post(qs->tls, TLS_P_NONE, tls_vec(&in, p, hs_len), &vec);
+		ret = tls_handshake_post(qs->tls, TLS_P_NONE, tls_vec(&in, p, hs_len));
 		switch (ret) {
 		case TLS_P_NONE:
 			break;
@@ -682,7 +682,7 @@ static int quic_frame_crypto_process(struct quic_sock *qs, u8 **ptr, u8 type, u3
 	}
 
 	/* process */
-	ret = tls_handshake(qs->tls, tls_vec(&in, p, hs_len), &vec);
+	ret = tls_handshake(qs->tls, tls_vec(&in, p, hs_len));
 	switch (ret) {
 	case TLS_ST_START:
 		break;
@@ -695,7 +695,7 @@ static int quic_frame_crypto_process(struct quic_sock *qs, u8 **ptr, u8 type, u3
 
 			qs->state = QUIC_CS_SERVER_WAIT_HANDSHAKE;
 			quic_crypto_handshake_keys_install(qs);
-			err = tls_handshake(qs->tls, NULL, &vec);
+			err = tls_handshake(qs->tls, tls_vec(&vec, NULL, 0));
 			if (err < 0)
 				return err;
 			err = quic_frame_create(qs, QUIC_FRAME_CRYPTO);

--- a/net/quic/proto.c
+++ b/net/quic/proto.c
@@ -1087,14 +1087,14 @@ static int quic_setsockopt_events(struct sock *sk, u32 *events, unsigned int len
 static int quic_setsockopt_new_ticket(struct sock *sk, u8 *pskid, unsigned int len)
 {
 	struct quic_sock *qs = quic_sk(sk);
-	struct tls_vec id, vec;
 	struct sk_buff *skb;
+	struct tls_vec vec;
 	int err;
 
 	if (qs->state != QUIC_CS_SERVER_POST_HANDSHAKE)
 		return -EINVAL;
 
-	err = tls_handshake_post(qs->tls, TLS_P_TICKET, tls_vec(&id, pskid, len), &vec);
+	err = tls_handshake_post(qs->tls, TLS_P_TICKET, tls_vec(&vec, pskid, len));
 	if (err)
 		return err;
 	qs->packet.ticket = quic_packet_create(qs, QUIC_PKT_SHORT, QUIC_FRAME_CRYPTO);


### PR DESCRIPTION
This patch adds an API tls_gen_handshake(sock) to do tls handshake based on an
established tcp socket. It includes psk/resumption/certificate_chain/early_data
supports and key setup via keyring.

This API makes kernel tls hs more simple for NFS use. It also adds a sockopt
TCP_TLS_HS to show how this can be used, which also makes it possible to do
tls hs for userspace socket.

Signed-off-by: Xin Long <lucien.xin@gmail.com>